### PR TITLE
Fix bug when user pastes non-string

### DIFF
--- a/src/__test__/plugin-test.js
+++ b/src/__test__/plugin-test.js
@@ -379,6 +379,14 @@ describe('draft-js-markdown-shortcuts-plugin', () => {
             expect(subject()).to.equal('not-handled');
           });
         });
+        describe('non-string empty value in clipboard', () => {
+          beforeEach(() => {
+            pastedText = null;
+          });
+          it('returns not-handled', () => {
+            expect(subject()).to.equal('not-handled');
+          });
+        });
         describe('pasted just text', () => {
           beforeEach(() => {
             pastedText = 'hello';

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,11 @@ const createMarkdownShortcutsPlugin = (config = { insertEmptyBlockOnReturnWithMo
       if (html) {
         return 'not-handled';
       }
+
+      if (!text) {
+        return 'not-handled';
+      }
+
       let newEditorState = editorState;
       let buffer = [];
       for (let i = 0; i < text.length; i++) { // eslint-disable-line no-plusplus


### PR DESCRIPTION
I don’t know how people manage to get non-strings into their clipboard but I was seeing a bunch of errors in sentry "length of undefined" and tracked it down to this plugin.

To re-create on mac

1. Open terminal, execute following command: `pbcopy < /dev/null`
2. Paste in a draft editor that uses this plugin
3. You will see an error in your console

Fix is to early-return if `text` has no value, instead of trying to loop through it.