### PR TITLE
Fix new function signature of handleBeforeInput

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ const createMarkdownShortcutsPlugin = (config = { insertEmptyBlockOnReturnWithMo
       }
       return 'not-handled';
     },
-    handleBeforeInput(character, editorState, { setEditorState }) {
+    handleBeforeInput(character, editorState, eventTimeStamp, { setEditorState }) {
       if (character.match(/[A-z0-9_*~`]/)) {
         return 'not-handled';
       }


### PR DESCRIPTION
Found this here https://github.com/ngs/draft-js-markdown-shortcuts-plugin/pull/62

It is required to use with new draft